### PR TITLE
Use np.load and np.save for stable data storage

### DIFF
--- a/sheet.md
+++ b/sheet.md
@@ -362,10 +362,10 @@ evals, evecs = np.linalg.eigh(a)     # np.linalg.eig for hermitian matrix
 
 ```python
 
-np.fromfile(fname/fobject, dtype=np.float32, count=5)  # binary data from file
 np.loadtxt(fname/fobject, skiprows=2, delimiter=',')   # ascii data from file
 np.savetxt(fname/fobject, array, fmt='%.5f')           # write ascii data
-np.tofile(fname/fobject)                               # write (C) binary data
+np.save(fname/fobject, array)                          # save binary data
+np.load(fname/fobject, mmap_mode='c')                  # load binary data (memory mapped)
 ```
 
 ### interpolation, integration, optimization


### PR DESCRIPTION
According to the [NumPy documentation](http://docs.scipy.org/doc/numpy/reference/generated/numpy.fromfile.html):

> Do not rely on the combination of tofile and fromfile for data storage, as the binary files generated are are not platform independent. In particular, no byte-order or data-type information is saved. Data can be stored in the platform independent .npy format using save and load instead.

I gave an example using copy-on-write memory mapping, which should save memory in the common case without surprising people by writing changes back to disk.
